### PR TITLE
make factory for 3 payment types

### DIFF
--- a/src/main/java/org/patterns/factory/FactoryExample.java
+++ b/src/main/java/org/patterns/factory/FactoryExample.java
@@ -1,0 +1,22 @@
+package org.patterns.factory;
+
+import org.patterns.factory.enums.PaymentType;
+import org.patterns.factory.interfaces.PaymentFactory;
+import org.patterns.factory.interfaces.PaymentMethod;
+
+import java.math.BigDecimal;
+
+public class FactoryExample {
+    public static void main(String[] args) {
+        PaymentMethod cardPayment = PaymentFactory.getPaymentType(PaymentType.CARD);
+        cardPayment.processPayment(BigDecimal.valueOf(1000.00));
+
+        PaymentMethod ibanPayment = PaymentFactory.getPaymentType(PaymentType.IBAN);
+        ibanPayment.processPayment(BigDecimal.valueOf(2000.00));
+
+        PaymentMethod paypalPayment = PaymentFactory.getPaymentType(PaymentType.PAYPAL);
+        paypalPayment.processPayment(BigDecimal.valueOf(3000.00));
+
+
+    }
+}

--- a/src/main/java/org/patterns/factory/enums/PaymentType.java
+++ b/src/main/java/org/patterns/factory/enums/PaymentType.java
@@ -1,0 +1,5 @@
+package org.patterns.factory.enums;
+
+public enum PaymentType {
+    CARD, PAYPAL, IBAN
+}

--- a/src/main/java/org/patterns/factory/interfaces/PaymentFactory.java
+++ b/src/main/java/org/patterns/factory/interfaces/PaymentFactory.java
@@ -1,0 +1,26 @@
+package org.patterns.factory.interfaces;
+
+import org.patterns.factory.enums.PaymentType;
+import org.patterns.factory.interfaces.impl.CardPayment;
+import org.patterns.factory.interfaces.impl.IbanPayment;
+import org.patterns.factory.interfaces.impl.PaypalPayment;
+
+public interface PaymentFactory {
+
+    static PaymentMethod getPaymentType(PaymentType paymentType) {
+        switch (paymentType.name().toLowerCase()) {
+            case "card" -> {
+                return new CardPayment();
+            }
+            case "iban" -> {
+                return new IbanPayment();
+            }
+            case "paypal" -> {
+                return new PaypalPayment();
+            }
+            default -> throw new IllegalArgumentException("Invalid payment type: " + paymentType);
+
+        }
+    }
+
+}

--- a/src/main/java/org/patterns/factory/interfaces/PaymentMethod.java
+++ b/src/main/java/org/patterns/factory/interfaces/PaymentMethod.java
@@ -1,0 +1,9 @@
+package org.patterns.factory.interfaces;
+
+import java.math.BigDecimal;
+
+public interface PaymentMethod {
+
+    void processPayment(BigDecimal amount);
+
+}

--- a/src/main/java/org/patterns/factory/interfaces/impl/CardPayment.java
+++ b/src/main/java/org/patterns/factory/interfaces/impl/CardPayment.java
@@ -1,0 +1,13 @@
+package org.patterns.factory.interfaces.impl;
+
+import org.patterns.factory.interfaces.PaymentMethod;
+
+import java.math.BigDecimal;
+
+public class CardPayment implements PaymentMethod {
+
+    @Override
+    public void processPayment(BigDecimal amount) {
+        System.out.println("Card Payment: " + amount);
+    }
+}

--- a/src/main/java/org/patterns/factory/interfaces/impl/IbanPayment.java
+++ b/src/main/java/org/patterns/factory/interfaces/impl/IbanPayment.java
@@ -1,0 +1,12 @@
+package org.patterns.factory.interfaces.impl;
+
+import org.patterns.factory.interfaces.PaymentMethod;
+
+import java.math.BigDecimal;
+
+public class IbanPayment implements PaymentMethod {
+    @Override
+    public void processPayment(BigDecimal amount) {
+        System.out.println("Iban Payment: " + amount);
+    }
+}

--- a/src/main/java/org/patterns/factory/interfaces/impl/PaypalPayment.java
+++ b/src/main/java/org/patterns/factory/interfaces/impl/PaypalPayment.java
@@ -1,0 +1,12 @@
+package org.patterns.factory.interfaces.impl;
+
+import org.patterns.factory.interfaces.PaymentMethod;
+
+import java.math.BigDecimal;
+
+public class PaypalPayment implements PaymentMethod {
+    @Override
+    public void processPayment(BigDecimal amount) {
+        System.out.println("Paypal Payment: " + amount);
+    }
+}


### PR DESCRIPTION
- Introduces enum-driven type safety (PaymentType).
- Standardizes payment processing via PaymentMethod interface.
- Provides concrete implementations for Card, PayPal, and IBAN.
- Centralizes creation logic in PaymentFactory for scalability.
- Includes demo (FactoryExample) for clarity.